### PR TITLE
ci: add required Python unit-test step to Docker Compose CI

### DIFF
--- a/.github/workflows/grafana-docker-compose-ci.yml
+++ b/.github/workflows/grafana-docker-compose-ci.yml
@@ -26,6 +26,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run Python unit tests
+        run: python -m unittest discover -s tests -p 'test_*.py'
+
       - name: Generate SSL/TLS certificates
         run: |
           mkdir -p certs


### PR DESCRIPTION
### Motivation

- Ensure Python unit tests run and block the CI early in the workflow by making Python explicitly available and running tests before integration checks.
- Catch Python-level regressions quickly by adding a required `unittest` discovery step to the existing Docker Compose CI flow.

### Description

- Added a `Set up Python` step using `actions/setup-python@v5` with `python-version: '3.x'` in `.github/workflows/grafana-docker-compose-ci.yml`.
- Added a required `Run Python unit tests` step that runs `python -m unittest discover -s tests -p 'test_*.py'` and placed it before the Docker Compose integration checks.
- The new test step is not soft-failed (no `|| true`) so failures will block the workflow.

### Testing

- Ran `python -m unittest discover -s tests -p 'test_*.py'` in this environment and it failed with `ImportError: Start directory is not importable: 'tests'`, indicating there are no importable tests present locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a903c64a4c833092c40e18cf04ea79)