### PR TITLE
Enforce docker-compose CI probe failures

### DIFF
--- a/.github/workflows/grafana-docker-compose-ci.yml
+++ b/.github/workflows/grafana-docker-compose-ci.yml
@@ -45,18 +45,16 @@ jobs:
       - name: Wait longer for services to fully start
         run: sleep 60
 
-      - name: Verify Nginx configuration
-        run: docker compose run --rm nginx nginx -t || true
+      - name: Verify Nginx configuration (gating)
+        run: docker compose run --rm nginx nginx -t
 
-      - name: Test connection to Nginx
+      - name: Probe Nginx HTTPS endpoint (gating)
         run: |
-          # Try connecting to Nginx directly
-          curl -v --retry 10 --retry-delay 10 --retry-connrefused --insecure https://localhost || true
+          curl --fail --show-error --retry 10 --retry-delay 10 --retry-connrefused --insecure https://localhost
 
-      - name: Test connection to Grafana
+      - name: Probe Grafana HTTP endpoint (gating)
         run: |
-          # Try connecting to Grafana directly
-          curl -v --retry 5 --retry-delay 5 --retry-connrefused http://localhost:3000 || true
+          curl --fail --show-error --retry 5 --retry-delay 5 --retry-connrefused http://localhost:3000
 
       - name: Stop and remove services
         run: docker compose down -v


### PR DESCRIPTION
### Motivation
- Ensure that configuration and runtime probes in the CI workflow fail the job on error instead of being silently ignored.
- Make probe steps explicitly gating so CI provides meaningful feedback when Nginx or Grafana endpoints are unhealthy.

### Description
- Updated `.github/workflows/grafana-docker-compose-ci.yml` to remove the `|| true` from the Nginx config verification and renamed the step to `Verify Nginx configuration (gating)` so failures are non-zero and fail the job.
- Replaced the Nginx HTTPS probe with a gating step named `Probe Nginx HTTPS endpoint (gating)` and made the command use `curl --fail --show-error` while preserving `--retry`, `--retry-delay`, and `--retry-connrefused` behavior.
- Replaced the Grafana probe with a gating step named `Probe Grafana HTTP endpoint (gating)` and made the command use `curl --fail --show-error` while preserving retry options.
- Kept the overall retry behavior intact so transient startup timing issues can be retried, but ensured persistent failures return non-zero exit codes.

### Testing
- Parsed the updated workflow file with Ruby's YAML loader using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/grafana-docker-compose-ci.yml')"`, which succeeded and confirmed valid YAML.
- Attempted to parse with Python `PyYAML` via `python -c 'import yaml'` which failed because `PyYAML` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a903c33f388330a12e87d37deffb8b)