### PR TITLE
Harden CI workflow permissions and update actions/checkout to v4

### DIFF
--- a/.github/workflows/grafana-docker-compose-ci.yml
+++ b/.github/workflows/grafana-docker-compose-ci.yml
@@ -10,6 +10,7 @@ on:
       - 'useful-scripts/install_docker_debian.sh'
       - 'useful-scripts/install_docker_ubuntu.sh'
       - 'certs/*'
+
   pull_request:
     paths-ignore:
       - '.gitignore'
@@ -19,12 +20,15 @@ on:
       - 'useful-scripts/install_docker_ubuntu.sh'
       - 'certs/*'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate SSL/TLS certificates
         run: |


### PR DESCRIPTION
### Motivation
- Reduce CI privileges and use the newer `actions/checkout` release to improve security and compatibility of the Grafana container CI workflow.

### Description
- Update `.github/workflows/grafana-docker-compose-ci.yml` to add a top-level `permissions: contents: read` entry and change the checkout step from `actions/checkout@v3` to `actions/checkout@v4`.

### Testing
- Validated the edited workflow file with `git diff`, `sed -n '1,80p'`, and `git show --stat --oneline HEAD`; all commands completed successfully and the workflow YAML change was not executed as a run-time job.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a903dcf0c48330b577cda3056afacf)