### PR TITLE
Ensure docker-compose teardown always runs in CI

### DIFF
--- a/.github/workflows/grafana-docker-compose-ci.yml
+++ b/.github/workflows/grafana-docker-compose-ci.yml
@@ -58,5 +58,10 @@ jobs:
           # Try connecting to Grafana directly
           curl -v --retry 5 --retry-delay 5 --retry-connrefused http://localhost:3000 || true
 
+      - name: Dump docker-compose logs on failure
+        if: failure()
+        run: docker compose logs
+
       - name: Stop and remove services
-        run: docker compose down -v
+        if: always()
+        run: docker compose down -v --remove-orphans


### PR DESCRIPTION
### Motivation
- Guarantee that the docker-compose stack is cleaned up even if earlier workflow steps fail and provide optional logs for failed runs to aid debugging.

### Description
- Add a failure-only step with `if: failure()` that runs `docker compose logs` to capture container output on failures.
- Make the teardown step run unconditionally with `if: always()` and change the command to `docker compose down -v --remove-orphans` to remove volumes and orphaned containers.
- Update performed in `.github/workflows/grafana-docker-compose-ci.yml` to reflect these changes.

### Testing
- Inspected the workflow file with `sed -n` and `nl` to verify the new `Dump docker-compose logs on failure` step and the `if: always()` teardown were added successfully.
- Applied the patch using the repository patch tool which reported success when updating the workflow file.
- Verified the resulting diff with `git diff -- .github/workflows/grafana-docker-compose-ci.yml` and confirmed the working tree with `git status --short`, both showing the intended modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a903cd26e88330b3d9ff0cb7f4ef87)