### PR TITLE
Require explicit Grafana admin password (no default fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 
 # Grafana admin credentials
 GRAFANA_ADMIN_USER=admin
-GRAFANA_ADMIN_PASSWORD=admin
+GRAFANA_ADMIN_PASSWORD=change-me-to-a-strong-password
 
 # Nginx server name
 NGINX_SERVER_NAME=localhost

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Copy `.env.example` to `.env` and adjust the variables:
 cp .env.example .env
 ```
 
-- `GRAFANA_ADMIN_USER` and `GRAFANA_ADMIN_PASSWORD` set the initial Grafana credentials.
+- `GRAFANA_ADMIN_USER` and `GRAFANA_ADMIN_PASSWORD` set the initial Grafana credentials. `GRAFANA_ADMIN_PASSWORD` is required and must be set explicitly in `.env` (no default fallback).
 - `NGINX_SERVER_NAME` defines the hostname served by Nginx.
 - `SSL_CERT_PATH` and `SSL_KEY_PATH` point to your certificate files.
 
@@ -133,7 +133,7 @@ docker compose up -d
 ```
 
 2. Access Grafana by navigating to `https://localhost` in your web browser.
-3. Default login user is usually `admin` for both username and password (unless configured otherwise).
+3. Sign in with the credentials you configured in `.env` (`GRAFANA_ADMIN_USER` and `GRAFANA_ADMIN_PASSWORD`).
 4. Configure data sources and dashboards as per your requirements.
 
 > For example, to add a Prometheus data source:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     image: grafana/grafana:12.0.1-ubuntu
     container_name: grafana
     restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in .env}
     ports:
       - "3000:3000"
     volumes:

--- a/tests/test_infra_config.py
+++ b/tests/test_infra_config.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_grafana_admin_password_has_no_admin_fallback() -> None:
+    compose = Path('docker-compose.yml').read_text()
+
+    assert 'GF_SECURITY_ADMIN_PASSWORD' in compose
+    assert 'GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in .env}' in compose
+    password_line = next(
+        line.strip()
+        for line in compose.splitlines()
+        if line.strip().startswith('GF_SECURITY_ADMIN_PASSWORD:')
+    )
+
+    assert ':-admin' not in password_line


### PR DESCRIPTION
### Motivation

- Remove the insecure implicit `admin` password fallback and force users to provide a strong admin password via environment configuration.  
- Update docs and examples to make the requirement clear and avoid misleading guidance that the default is `admin/admin`.

### Description

- Updated `docker-compose.yml` to set Grafana env vars and require `GRAFANA_ADMIN_PASSWORD` with the Docker Compose parameter expansion `
  ${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in .env}` so startup will fail without an explicit password.  
- Kept `GRAFANA_ADMIN_USER` configurable and left a sensible default via `${GRAFANA_ADMIN_USER:-admin}`.  
- Updated `.env.example` to replace `GRAFANA_ADMIN_PASSWORD=admin` with a placeholder `change-me-to-a-strong-password` to discourage weak defaults.  
- Clarified `README.md` to state that `GRAFANA_ADMIN_PASSWORD` is required and removed the suggestion that the default login is `admin/admin`.  
- Added `tests/test_infra_config.py` which asserts the compose file contains the required password setting and that no `:-admin` fallback remains on the password line.

### Testing

- Ran `pytest -q` which executed the new test `test_grafana_admin_password_has_no_admin_fallback` and completed successfully.  
- The test verifies the `GF_SECURITY_ADMIN_PASSWORD` compose entry uses the `:?` expansion and that the `:-admin` fallback is not present, and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a903e0d0148330ba85b835a74eeb2d)