### PR TITLE
ci: poll Grafana and Nginx health in workflow instead of fixed sleep

### DIFF
--- a/.github/workflows/grafana-docker-compose-ci.yml
+++ b/.github/workflows/grafana-docker-compose-ci.yml
@@ -54,8 +54,40 @@ jobs:
       - name: Check docker-compose logs
         run: docker compose logs
 
-      - name: Wait longer for services to fully start
-        run: sleep 60
+      - name: Wait for Grafana and Nginx health checks
+        run: |
+          set -euo pipefail
+          timeout_secs=180
+          interval_secs=5
+          elapsed=0
+
+          while [ "$elapsed" -lt "$timeout_secs" ]; do
+            grafana_container="$(docker compose ps -q grafana)"
+            nginx_container="$(docker compose ps -q nginx)"
+
+            if [ -z "$grafana_container" ] || [ -z "$nginx_container" ]; then
+              echo "Waiting for containers to be created..."
+            else
+              grafana_health="$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$grafana_container")"
+              nginx_health="$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$nginx_container")"
+
+              echo "grafana health: $grafana_health"
+              echo "nginx health: $nginx_health"
+
+              if [ "$grafana_health" = "healthy" ] && [ "$nginx_health" = "healthy" ]; then
+                echo "Grafana and Nginx are healthy."
+                exit 0
+              fi
+            fi
+
+            sleep "$interval_secs"
+            elapsed=$((elapsed + interval_secs))
+          done
+
+          echo "Timed out after ${timeout_secs}s waiting for Grafana and Nginx to become healthy."
+          docker compose ps
+          docker compose logs
+          exit 1
 
       - name: Verify Nginx configuration (gating)
         run: docker compose run --rm nginx nginx -t


### PR DESCRIPTION
### Motivation
- Remove a brittle fixed delay (`sleep 60`) and replace it with active health polling to make the CI workflow more deterministic and faster when services become ready earlier. 
- Ensure the job fails visibly with diagnostics when required services do not reach healthy state within a reasonable timeout.

### Description
- Replaced the `- name: Wait longer for services to fully start` step (previously `sleep 60`) with a polling loop that queries container presence via `docker compose ps -q` and container health via `docker inspect`.
- The new loop checks both `grafana` and `nginx` for `healthy` status every `5` seconds and uses a `180` second timeout before failing.
- The step uses `set -euo pipefail` for stricter shell behavior and prints periodic status lines like `grafana health: ...` and `nginx health: ...` while waiting.
- On timeout the step prints `docker compose ps` and `docker compose logs` and exits non-zero to provide diagnostics to CI logs.

### Testing
- No automated CI jobs were executed locally because this change modifies a GitHub Actions workflow and requires being run by the CI runner; no automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a903c9abc483309e61d2b1b74c8d7d)