### PR TITLE
Fix CI docker compose startup by preparing .env

### DIFF
--- a/.github/workflows/grafana-docker-compose-ci.yml
+++ b/.github/workflows/grafana-docker-compose-ci.yml
@@ -46,9 +46,7 @@ jobs:
           openssl x509 -req -days 365 -in certs/server.csr -signkey certs/server.key -out certs/server.crt
 
       - name: Prepare environment variables for docker compose
-        run: |
-          cp .env.example .env
-          sed -i 's/^GRAFANA_ADMIN_PASSWORD=.*/GRAFANA_ADMIN_PASSWORD=ci-admin-password/' .env
+        run: cp .env.example .env
 
       - name: Start services
         run: docker compose up -d

--- a/.github/workflows/grafana-docker-compose-ci.yml
+++ b/.github/workflows/grafana-docker-compose-ci.yml
@@ -45,6 +45,11 @@ jobs:
           openssl req -new -key certs/server.key -out certs/server.csr -subj "/CN=localhost"
           openssl x509 -req -days 365 -in certs/server.csr -signkey certs/server.key -out certs/server.crt
 
+      - name: Prepare environment variables for docker compose
+        run: |
+          cp .env.example .env
+          sed -i 's/^GRAFANA_ADMIN_PASSWORD=.*/GRAFANA_ADMIN_PASSWORD=ci-admin-password/' .env
+
       - name: Start services
         run: docker compose up -d
 


### PR DESCRIPTION
### Motivation
- The GitHub Actions job failed because `docker compose` interpolates `GRAFANA_ADMIN_PASSWORD` from `.env` and the variable was not set in CI, causing startup to abort. 

### Description
- Added a workflow step in `.github/workflows/grafana-docker-compose-ci.yml` to copy `.env.example` to `.env` before `docker compose up -d` runs. 
- The step sets a deterministic CI password by running `sed -i 's/^GRAFANA_ADMIN_PASSWORD=.*/GRAFANA_ADMIN_PASSWORD=ci-admin-password/' .env` so compose interpolation succeeds. 

### Testing
- Ran unit tests with `python -m unittest discover -s tests -p 'test_*.py'`, which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a906fa558c83309f5992ba623169fb)